### PR TITLE
Fix smooth scroll bug

### DIFF
--- a/docs/assets/js/script.js
+++ b/docs/assets/js/script.js
@@ -21,8 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const navLinks = document.querySelectorAll('a[href^="#"]');
   navLinks.forEach(link => {
     link.addEventListener('click', function(e) {
-      e.preventDefault();
       const targetId = this.getAttribute('href');
+      if (!targetId || targetId === '#') {
+        return; // Ignore empty anchors
+      }
+      e.preventDefault();
       const targetElement = document.querySelector(targetId);
       if (targetElement) {
         targetElement.scrollIntoView({


### PR DESCRIPTION
## Summary
- avoid JavaScript error when clicking anchor links that use `href="#"`

## Testing
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c08ff27c83268086d5ab86094862